### PR TITLE
Use RSpec 3 method of getting parent example group

### DIFF
--- a/lib/rspec_junit_formatter/rspec3.rb
+++ b/lib/rspec_junit_formatter/rspec3.rb
@@ -45,8 +45,8 @@ private
 
   def example_group_file_path_for(notification)
     meta = notification.example.metadata
-    while meta[:example_group]
-      meta = meta[:example_group]
+    while meta[:parent_example_group]
+      meta = meta[:parent_example_group]
     end
     meta[:file_path]
   end


### PR DESCRIPTION
From https://github.com/rspec/rspec-core/pull/1391 the method of extracting parent example group changed.

In latest 3.1.x it started causing the return code to be 1, breaking all specs.
