### PR TITLE
The `:example_group` key in an example group's metadata hash is deprecated

### DIFF
--- a/lib/rspec_junit_formatter/rspec3.rb
+++ b/lib/rspec_junit_formatter/rspec3.rb
@@ -45,8 +45,8 @@ private
 
   def example_group_file_path_for(notification)
     meta = notification.example.metadata
-    while meta[:example_group]
-      meta = meta[:example_group]
+    while meta[:parent_example_group]
+      meta = meta[:parent_example_group]
     end
     meta[:file_path]
   end


### PR DESCRIPTION
Using this with RSpec 3 gives a deprecation warning:

```
/home/ubuntu/.rvm/gems/ruby-2.2.0@global/gems/rspec-core-3.1.7/lib/rspec/core/formatters/deprecation_formatter.rb:186:in `puts': The `:example_group` key in an example group's metadata hash is deprecated. Use the example group's hash directly for the computed keys and `:parent_example_group` to access the parent example group metadata instead. Called from /home/ubuntu/amitree/vendor/bundle/ruby/2.2.0/bundler/gems/rspec_junit_formatter-7b098c8ab2ac/lib/rspec_junit_formatter/rspec3.rb:48:in `yield'. (RSpec::Core::DeprecationError)
```
