### PR TITLE
Don't use deprecated metadata example_group hash entry

### DIFF
--- a/lib/rspec_junit_formatter/rspec3.rb
+++ b/lib/rspec_junit_formatter/rspec3.rb
@@ -45,9 +45,11 @@ private
 
   def example_group_file_path_for(notification)
     meta = notification.example.metadata
-    while meta[:example_group]
-      meta = meta[:example_group]
+
+    while meta[:parent_example_group] do
+     meta = meta[:parent_example_group]
     end
+    
     meta[:file_path]
   end
 


### PR DESCRIPTION
Fixes the problem below when using rspec 3+

The `:example_group` key in an example group's metadata hash is deprecated. Use the example group's hash directly for the computed keys and `:parent_example_group` to access the parent example group metadata instead. Called from /home/ubuntu/dandelion/vendor/bundle/ruby/2.1.0/bundler/gems/rspec_junit_formatter-7b098c8ab2ac/lib/rspec_junit_formatter/rspec3.rb:48:in `yield'. (RSpec::Core::DeprecationError)